### PR TITLE
Escape spaces when printing file path for screenshots.

### DIFF
--- a/lithograph/test-worker/screenshots.js
+++ b/lithograph/test-worker/screenshots.js
@@ -15,7 +15,7 @@ module.exports = async function (browser, screenshotsPath)
         const results = await Promise.all(pages
             .map((page, index) => [page, `${screenshotsPath}/page-${index}.png`])
             .map(([page, path]) => page.screenshot({ path })
-                .then(() => path)
+                .then(() => path.replace(/ /g, "\ ")
                 .catch((e) => console.log(e))));
 
         console.log(results);


### PR DESCRIPTION
This makes it easier to copy and open the file in the terminal.